### PR TITLE
Update python_version 3.13 phase 5

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -1,0 +1,2 @@
+[MASTER]
+ignore=.venv

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,2 +1,3 @@
 **Unreleased**
 * Resolved app issues related to Python 3.13 upgrade
+* Update Python version for 3.13

--- a/rss.json
+++ b/rss.json
@@ -15,7 +15,7 @@
     "package_name": "phantom_rss",
     "main_module": "rss_connector.py",
     "min_phantom_version": "6.1.1",
-    "python_version": "3",
+    "python_version": "3.9, 3.13",
     "fips_compliant": true,
     "latest_tested_versions": [
         "feedparser-6.0.2"


### PR DESCRIPTION
- Update python_version in app JSON files to support Python 3.9 and 3.13 for phase 5 part 2

[_Created by Sourcegraph batch change `grokas-splunk/python-versions-3.13-phase5-part2`._](https://sourcegraph.splunkdev.net/users/grokas-splunk/batch-changes/python-versions-3.13-phase5-part2)